### PR TITLE
Feat: Add API of retrieve restaurant by host id (#88)

### DIFF
--- a/service/views.py
+++ b/service/views.py
@@ -65,10 +65,13 @@ class RestaurantList(generics.ListCreateAPIView):
         queryset = Restaurant.objects.all()
         district = self.request.query_params.get('district', None)
         key = self.request.query_params.get('key', None)
+        host = self.request.query_params.get('host', None)
         if district is not None:
             queryset = queryset.filter(district=district)
         if key is not None:
             queryset = queryset.filter(name__contains=key)
+        if host is not None:
+            queryset = queryset.filter(host_id=host)
         return queryset
 
 


### PR DESCRIPTION
## Title
> Add API of retrieve restaurant by host id (#88)
## Details
- [x] Use query parameter to retrieve restaurant 
```python
class RestaurantList(generics.ListCreateAPIView):
    queryset = Restaurant.objects.all()
    serializer_class = RestaurantSerializer
    def get_queryset(self):
        queryset = Restaurant.objects.all()
        district = self.request.query_params.get('district', None)
        key = self.request.query_params.get('key', None)
        host = self.request.query_params.get('host', None)
        if district is not None:
            queryset = queryset.filter(district=district)
        if key is not None:
            queryset = queryset.filter(name__contains=key)
        if host is not None:
            queryset = queryset.filter(host_id=host)
        return queryset
```
